### PR TITLE
[ENH]+[FIX] lc0.0.2 ready, fix import problems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "launchcontainers"
-version = "0.0.1"
+version = "0.0.2"
 description = "Launch Containers Package"
 authors = [ "BCBL", "CompNeuroLabBilbao",
             "Yongning Lei",

--- a/src/launchcontainers/launch.py
+++ b/src/launchcontainers/launch.py
@@ -21,9 +21,9 @@ import logging
 from bids import BIDSLayout
 from dask.distributed import progress
 
-import dask_scheduler_config as dsq
-import prepare as prepare
-import utils as do
+from launchcontainers import dask_scheduler_config as dsq
+from launchcontainers import prepare as prepare
+from launchcontainers import utils as do
 
 logger=logging.getLogger("GENERAL")
 

--- a/src/launchcontainers/prepare.py
+++ b/src/launchcontainers/prepare.py
@@ -25,8 +25,8 @@ from glob import glob
 import numpy as np 
 from scipy.io import loadmat
 
-import utils as do
-import prepare_dwi as dwipre
+from launchcontainers import utils as do
+from launchcontainers import prepare_dwi as dwipre
 
 logger=logging.getLogger("GENERAL")
 

--- a/src/launchcontainers/prepare_dwi.py
+++ b/src/launchcontainers/prepare_dwi.py
@@ -25,8 +25,8 @@ import subprocess as sp
 import zipfile
 import logging
 
-import utils as do
-from utils import read_df, copy_file 
+from launchcontainers import utils as do
+from launchcontainers.utils import read_df, copy_file 
 
 
 logger=logging.getLogger("GENERAL")


### PR DESCRIPTION
- [ENH] now lcv2 is ready on pypi with 0.0.2, it is good for ips
- [FIX] fix importing bugs when import other python scipts to the launch.py
- [find bug] when launch rtp-pipeline  on lmc02, there are bugs, fix tmr!